### PR TITLE
Search by type: use `createInputBox`

### DIFF
--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1107,6 +1107,28 @@ module ProviderResult = struct
     else `Value (or_undefined_of_js ml_of_js js_val)
 end
 
+module InputBoxValidationSeverity = struct
+  type t =
+    | Info [@js 1]
+    | Warning [@js 2]
+    | Error [@js 3]
+  [@@js.enum] [@@js]
+end
+
+module InputBoxValidationMessage = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val message : t -> string [@@js.get]
+
+    val severity : t -> InputBoxValidationSeverity.t [@@js.get]
+
+    val create :
+      message:string -> severity:InputBoxValidationSeverity.t -> unit -> t
+    [@@js.builder]]
+end
+
 module InputBoxOptions = struct
   include Interface.Make ()
 
@@ -1141,6 +1163,75 @@ module InputBoxOptions = struct
       -> unit
       -> t
     [@@js.builder]]
+end
+
+module InputBox = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val title : t -> string or_undefined [@@js.get]
+
+    val set_title : t -> string or_undefined -> unit [@@js.set]
+
+    val enabled : t -> bool [@@js.get]
+
+    val set_enabled : t -> bool -> unit [@@js.set]
+
+    val busy : t -> bool [@@js.get]
+
+    val set_busy : t -> bool -> unit [@@js.set]
+
+    val ignoreFocusOut : t -> bool or_undefined [@@js.get]
+
+    val set_ignoreFocusOut : t -> bool or_undefined -> unit [@@js.set]
+
+    val onDidHide : t -> unit Event.t [@@js.get]
+
+    val value : t -> string or_undefined [@@js.get]
+
+    val set_value : t -> string or_undefined -> unit [@@js.set]
+
+    val valueSelection : t -> (int * int) or_undefined [@@js.get]
+
+    val set_valueSelection : t -> (int * int) or_undefined -> unit [@@js.set]
+
+    val placeholder : t -> string or_undefined [@@js.get]
+
+    val set_placeholder : t -> string or_undefined -> unit [@@js.set]
+
+    val password : t -> bool or_undefined [@@js.get]
+
+    val set_password : t -> bool or_undefined -> unit [@@js.set]
+
+    val onDidChangeValue : t -> string Event.t [@@js.get]
+
+    val onDidAccept : t -> unit Event.t [@@js.get]
+
+    val prompt : t -> string or_undefined [@@js.get]
+
+    val set_prompt : t -> string or_undefined -> unit [@@js.set]
+
+    val validationMessage : t -> InputBoxValidationMessage.t or_undefined
+    [@@js.get]
+
+    val set_validationMessage :
+      t -> InputBoxValidationMessage.t or_undefined -> unit
+    [@@js.set]
+
+    val show : t -> unit [@@js.call]]
+
+  let set t ?title ?ignoreFocusOut ?value ?valueSelection ?placeholder ?password
+      ?prompt ?validationMessage () =
+    set_title t title;
+    set_ignoreFocusOut t ignoreFocusOut;
+    set_value t value;
+    set_valueSelection t valueSelection;
+    set_placeholder t placeholder;
+    set_password t password;
+    set_prompt t prompt;
+    set_validationMessage t validationMessage;
+    t
 end
 
 module OpenDialogOptions = struct
@@ -3053,6 +3144,9 @@ module Window = struct
       -> unit
       -> string or_undefined Promise.t
     [@@js.global "vscode.window.showInputBox"]
+
+    val createInputBox : unit -> InputBox.t
+    [@@js.global "vscode.window.createInputBox"]
 
     val showOpenDialog :
       ?options:OpenDialogOptions.t -> unit -> Uri.t list or_undefined Promise.t

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -872,6 +872,26 @@ module ProviderResult : sig
   include Js.Generic with type 'a t := 'a t
 end
 
+module InputBoxValidationSeverity : sig
+  type t =
+    | Info
+    | Warning
+    | Error
+
+  include Ojs.T with type t := t
+end
+
+module InputBoxValidationMessage : sig
+  include Ojs.T
+
+  val message : t -> string
+
+  val severity : t -> InputBoxValidationSeverity.t
+
+  val create :
+    message:string -> severity:InputBoxValidationSeverity.t -> unit -> t
+end
+
 module InputBoxOptions : sig
   include Ojs.T
 
@@ -900,6 +920,72 @@ module InputBoxOptions : sig
     -> ?password:bool
     -> ?ignoreFocusOut:bool
     -> ?validateInput:(value:string -> string option Promise.t)
+    -> unit
+    -> t
+end
+
+module InputBox : sig
+  include Ojs.T
+
+  val title : t -> string option
+
+  val set_title : t -> string option -> unit
+
+  val enabled : t -> bool
+
+  val set_enabled : t -> bool -> unit
+
+  val busy : t -> bool
+
+  val set_busy : t -> bool -> unit
+
+  val ignoreFocusOut : t -> bool option
+
+  val set_ignoreFocusOut : t -> bool option -> unit
+
+  val onDidHide : t -> unit Event.t
+
+  val value : t -> string option
+
+  val set_value : t -> string option -> unit
+
+  val valueSelection : t -> (int * int) option
+
+  val set_valueSelection : t -> (int * int) option -> unit
+
+  val placeholder : t -> string option
+
+  val set_placeholder : t -> string option -> unit
+
+  val password : t -> bool option
+
+  val set_password : t -> bool option -> unit
+
+  val onDidChangeValue : t -> string Event.t
+
+  val onDidAccept : t -> unit Event.t
+
+  val prompt : t -> string option
+
+  val set_prompt : t -> string option -> unit
+
+  val validationMessage : t -> InputBoxValidationMessage.t or_undefined
+
+  val set_validationMessage :
+    t -> InputBoxValidationMessage.t or_undefined -> unit
+
+  val show : t -> unit
+
+  val set :
+       t
+    -> ?title:string
+    -> ?ignoreFocusOut:bool
+    -> ?value:string
+    -> ?valueSelection:int * int
+    -> ?placeholder:string
+    -> ?password:bool
+    -> ?prompt:string
+    -> ?validationMessage:InputBoxValidationMessage.t
     -> unit
     -> t
 end
@@ -2363,6 +2449,8 @@ module Window : sig
     -> ?token:CancellationToken.t
     -> unit
     -> string option Promise.t
+
+  val createInputBox : unit -> InputBox.t
 
   val showOpenDialog :
     ?options:OpenDialogOptions.t -> unit -> Uri.t list option Promise.t


### PR DESCRIPTION
Using the lower-level `createInputBox` function gives us much more control on validation and  behavior.

In this PR I introduce bindings to this function and to the `InputBox` interface and use them to improve user feedback while waiting for an answer or when the results are empty. 